### PR TITLE
Mac support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
               HOST_GCC: 'gcc'
             }
           - {
-              OS: 'macos-latest',
+              OS: 'macos-14',
               CFLAGS: '-DDARWIN -std=gnu89 -Wno-return-type -Wno-error -Wno-implicit-function-declaration',
               HOST: 'i386-apple-darwin',
               ARCHIVE_NAME: 'mips-gcc-egcs-2.91.66-mac.tar.gz',
-              HOST_GCC: 'gcc-11'
+              HOST_GCC: 'gcc-13'
             }
 
     name: Building gcc for ${{ matrix.TARGET.OS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
               HOST_GCC: 'gcc'
             }
           - {
-              OS: 'macos-14',
+              OS: 'macos-13',
               CFLAGS: '-DDARWIN -std=gnu89 -Wno-return-type -Wno-error -Wno-implicit-function-declaration',
               HOST: 'i386-apple-darwin',
               ARCHIVE_NAME: 'mips-gcc-egcs-2.91.66-mac.tar.gz',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Make
         shell: bash
         run: |
-          touch gcc/c-parse.c   # makes `make` ignore regeneration of this file
+          touch gcc/c-parse.c gcc/cexp.c gcc/cp/parse.c  # makes `make` ignore regeneration of the .y files
           make -C gcc CFLAGS="${{ matrix.TARGET.CFLAGS }}" xgcc cc1 cc1plus cpp cccp g++
       - name: Test for file
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,16 @@ jobs:
               OS: 'ubuntu-20.04',
               CFLAGS: '-static -std=gnu89 -m32',
               HOST: 'i386-pc-linux',
-              ARCHIVE_NAME: 'mips-gcc-egcs-2.91.66-linux.tar.gz'
+              ARCHIVE_NAME: 'mips-gcc-egcs-2.91.66-linux.tar.gz',
+              HOST_GCC: 'gcc'
             }
-          # - {
-          #     OS: 'macos-latest',
-          #     CFLAGS: '-DDARWIN -std=gnu89 -Wno-return-type -Wno-error -Wno-implicit-function-declaration',
-          #     HOST: 'i386-apple-darwin',
-          #     ARCHIVE_NAME: 'mips-gcc-egcs-2.91.66-mac.tar.gz'
-          #   }
+          - {
+              OS: 'macos-latest',
+              CFLAGS: '-DDARWIN -std=gnu89 -Wno-return-type -Wno-error -Wno-implicit-function-declaration',
+              HOST: 'i386-apple-darwin',
+              ARCHIVE_NAME: 'mips-gcc-egcs-2.91.66-mac.tar.gz'
+              HOST_GCC: 'gcc-11'
+            }
 
     name: Building gcc for ${{ matrix.TARGET.OS }}
     steps:
@@ -35,11 +37,12 @@ jobs:
       - name: Configure for mips
         shell: bash
         run: |
-          ./configure --target=mips-linux --prefix=/opt/cross --with-gnu-as --disable-gprof --disable-gdb --disable-werror --host=${{ matrix.TARGET.HOST }} --build=${{ matrix.TARGET.HOST }}
+          CC="${{ matrix.TARGET.HOST_GCC }}" CFLAGS="-Wno-implicit-int" ./configure --target=mips-linux --prefix=/opt/cross --with-gnu-as --disable-gprof --disable-gdb --disable-werror --host=${{ matrix.TARGET.HOST }} --build=${{ matrix.TARGET.HOST }}
 
       - name: Make
         shell: bash
         run: |
+          touch gcc/c-parse.c   # makes `make` ignore regeneration of this file
           make -C gcc CFLAGS="${{ matrix.TARGET.CFLAGS }}" xgcc cc1 cc1plus cpp cccp g++
       - name: Test for file
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
               OS: 'macos-latest',
               CFLAGS: '-DDARWIN -std=gnu89 -Wno-return-type -Wno-error -Wno-implicit-function-declaration',
               HOST: 'i386-apple-darwin',
-              ARCHIVE_NAME: 'mips-gcc-egcs-2.91.66-mac.tar.gz'
+              ARCHIVE_NAME: 'mips-gcc-egcs-2.91.66-mac.tar.gz',
               HOST_GCC: 'gcc-11'
             }
 

--- a/config.sub
+++ b/config.sub
@@ -909,7 +909,7 @@ case $os in
 	      | -ptx* | -coff* | -ecoff* | -winnt* | -domain* | -vsta* \
 	      | -udi* | -eabi* | -lites* | -ieee* | -go32* | -aux* \
 	      | -cygwin32* | -pe* | -psos* | -moss* | -proelf* | -rtems* \
-	      | -mingw32* | -linux-gnu* | -uxpv*)
+	      | -mingw32* | -linux-gnu* | -uxpv* | -darwin* )
 	# Remember, each alternative MUST END IN *, to match a version number.
 		;;
 	# CYGNUS LOCAL

--- a/gcc/config.sub
+++ b/gcc/config.sub
@@ -732,7 +732,7 @@ case $os in
 	      | -ptx* | -coff* | -ecoff* | -winnt* | -domain* | -vsta* \
 	      | -udi* | -eabi* | -lites* | -ieee* | -go32* | -aux* \
 	      | -cygwin32* | -pe* | -psos* | -moss* | -proelf* | -rtems* \
-	      | -mingw32* | -linux-gnu* | -uxpv* | -beos* )
+	      | -mingw32* | -linux-gnu* | -uxpv* | -beos* | -darwin* )
 	# Remember, each alternative MUST END IN *, to match a version number.
 		;;
 	-linux*)

--- a/gcc/config/i386/xm-darwin.h
+++ b/gcc/config/i386/xm-darwin.h
@@ -1,0 +1,4 @@
+/* Configuration for GCC for Intel i386 or later running macOS as host.  */
+
+#include <alloca.h>
+#include "i386/xm-i386.h"

--- a/gcc/configure
+++ b/gcc/configure
@@ -2851,6 +2851,9 @@ for machine in $build $host $target; do
 # Next line turned off because both 386BSD and BSD/386 use GNU ld.
 #		use_collect2=yes
 		;;
+	i[34567]86-apple-darwin)	#macOS
+		xm_file=i386/xm-darwin.h
+		;;
 	i[34567]86-*-freebsdelf*)
 		tm_file="i386/i386.h i386/att.h linux.h i386/freebsd-elf.h i386/perform.h"
 		# On FreeBSD, the headers are already ok, except for math.h.

--- a/libiberty/strerror.c
+++ b/libiberty/strerror.c
@@ -461,11 +461,21 @@ static int sys_nerr;
 static const char **sys_errlist;
 
 #else
+#ifdef DARWIN
+
+// macOS added 'const' to these declarations, and clang complains if they are otherwise
+extern const int sys_nerr;
+extern const char *sys_errlist[];
+
+
+#else
 
 extern int sys_nerr;
 extern char *sys_errlist[];
 
 #endif
+#endif
+
 
 
 /*

--- a/libiberty/strerror.c
+++ b/libiberty/strerror.c
@@ -460,8 +460,7 @@ static int num_error_names = 0;
 static int sys_nerr;
 static const char **sys_errlist;
 
-#else
-#ifdef DARWIN
+#elif defined(DARWIN)
 
 // macOS added 'const' to these declarations, and clang complains if they are otherwise
 extern const int sys_nerr;
@@ -473,7 +472,6 @@ extern const char *sys_errlist[];
 extern int sys_nerr;
 extern char *sys_errlist[];
 
-#endif
 #endif
 
 


### PR DESCRIPTION
Adds this line: `touch gcc/c-parse.c gcc/cexp.c gcc/cp/parse.c` which stops make from regenerating with these files that was generated from outdated GNU Bison. Fixes #1 