### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -24,7 +24,7 @@ jobs:
 
     name: Building gcc for ${{ matrix.TARGET.OS }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies (Ubuntu)
         shell: bash
@@ -39,8 +39,10 @@ jobs:
 
       - name: Make
         shell: bash
-        run: |
+        run: | # The generated `c-parse.c` is already commited on the repo, so we touch it to avoid regenerating it (trying to build old lex/yacc files with modern tools fails)
+          touch c-parse.c
           make -C gcc CFLAGS="${{ matrix.TARGET.CFLAGS }}" xgcc cc1 cc1plus cpp cccp g++
+
       - name: Test for file
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Make
         shell: bash
         run: | # The generated `c-parse.c` is already commited on the repo, so we touch it to avoid regenerating it (trying to build old lex/yacc files with modern tools fails)
-          touch c-parse.c
+          touch gcc/c-parse.c
           make -C gcc CFLAGS="${{ matrix.TARGET.CFLAGS }}" xgcc cc1 cc1plus cpp cccp g++
 
       - name: Test for file

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
         shell: bash
         run: | # The generated `c-parse.c` is already commited on the repo, so we touch it to avoid regenerating it (trying to build old lex/yacc files with modern tools fails)
           touch gcc/c-parse.c
+          touch gcc/cp/parse.c
           make -C gcc CFLAGS="${{ matrix.TARGET.CFLAGS }}" xgcc cc1 cc1plus cpp cccp g++
 
       - name: Test for file

--- a/gcc/gcc.c
+++ b/gcc/gcc.c
@@ -121,6 +121,8 @@ static char dir_separator_str[] = {DIR_SEPARATOR, 0};
 #define GET_ENVIRONMENT(ENV_VALUE,ENV_NAME) ENV_VALUE = getenv (ENV_NAME)
 #endif
 
+extern char *my_strerror PROTO((int));
+
 #ifndef HAVE_KILL
 #define kill(p,s) raise(s)
 #endif
@@ -1085,7 +1087,13 @@ translate_options (argcp, argvp)
   *argvp = newv;
   *argcp = newindex;
 }
-
+
+char *
+my_strerror(e)
+     int e;
+{
+  return strerror(e);
+}
 
 static char *
 skip_whitespace (p)
@@ -5284,14 +5292,14 @@ static void
 pfatal_with_name (name)
      char *name;
 {
-  fatal ("%s: %s", name, strerror (errno));
+  fatal ("%s: %s", name, my_strerror (errno));
 }
 
 static void
 perror_with_name (name)
      char *name;
 {
-  error ("%s: %s", name, strerror (errno));
+  error ("%s: %s", name, my_strerror (errno));
 }
 
 static void
@@ -5309,7 +5317,7 @@ pfatal_pexecute (errmsg_fmt, errmsg_arg)
       errmsg_fmt = msg;
     }
 
-  fatal ("%s: %s", errmsg_fmt, strerror (save_errno));
+  fatal ("%s: %s", errmsg_fmt, my_strerror (save_errno));
 }
 
 /* More 'friendly' abort that prints the line and file.

--- a/gcc/gcc.c
+++ b/gcc/gcc.c
@@ -121,8 +121,6 @@ static char dir_separator_str[] = {DIR_SEPARATOR, 0};
 #define GET_ENVIRONMENT(ENV_VALUE,ENV_NAME) ENV_VALUE = getenv (ENV_NAME)
 #endif
 
-extern char *my_strerror PROTO((int));
-
 #ifndef HAVE_KILL
 #define kill(p,s) raise(s)
 #endif
@@ -1087,28 +1085,7 @@ translate_options (argcp, argvp)
   *argvp = newv;
   *argcp = newindex;
 }
-
-char *
-my_strerror(e)
-     int e;
-{
-#ifdef HAVE_STRERROR
 
-  return strerror(e);
-
-#else
-
-  static char buffer[30];
-  if (!e)
-    return "cannot access";
-
-  if (e > 0 && e < sys_nerr)
-    return sys_errlist[e];
-
-  sprintf (buffer, "Unknown error %d", e);
-  return buffer;
-#endif
-}
 
 static char *
 skip_whitespace (p)
@@ -5307,14 +5284,14 @@ static void
 pfatal_with_name (name)
      char *name;
 {
-  fatal ("%s: %s", name, my_strerror (errno));
+  fatal ("%s: %s", name, strerror (errno));
 }
 
 static void
 perror_with_name (name)
      char *name;
 {
-  error ("%s: %s", name, my_strerror (errno));
+  error ("%s: %s", name, strerror (errno));
 }
 
 static void
@@ -5332,7 +5309,7 @@ pfatal_pexecute (errmsg_fmt, errmsg_arg)
       errmsg_fmt = msg;
     }
 
-  fatal ("%s: %s", errmsg_fmt, my_strerror (save_errno));
+  fatal ("%s: %s", errmsg_fmt, strerror (save_errno));
 }
 
 /* More 'friendly' abort that prints the line and file.


### PR DESCRIPTION
Ports over this PR: https://github.com/decompals/mips-gcc-2.7.2/pull/8

- Touches `c-parse.c` to avoid regenerating it, since we are not installing old lex/yacc during the CI build 
- Changes the ci to also build on PRs
- Updates some outdated actions
  - `actions/checkout@v2` -> `actions/checkout@v4`
  - `actions/upload-artifact@v2` -> `actions/upload-artifact@v3`
- Get rid of `my_strerror`, since it can sometimes can issues because of missing `sys_errlist` on modern systems