### PR TITLE
Fix const doubles on macOS

### DIFF
--- a/gcc/config/a29k/a29k.c
+++ b/gcc/config/a29k/a29k.c
@@ -1108,7 +1108,7 @@ print_operand (file, x, code)
 	{
 	  union real_extract u;
 
-	  bcopy ((char *) &CONST_DOUBLE_LOW (x), (char *) &u, sizeof u);
+	  REAL_VALUE_FROM_CONST_DOUBLE (u.d, x);
 	  fprintf (file, "$double1(%.20e)", u.d);
 	}
       else if (GET_CODE (x) == REG)
@@ -1172,8 +1172,7 @@ print_operand (file, x, code)
 	fprintf (file, "$float");
       else
 	fprintf (file, "$double%d", SUBREG_WORD (XEXP (x, 0)));
-      bcopy ((char *) &CONST_DOUBLE_LOW (SUBREG_REG (XEXP (x, 0))),
-	     (char *) &u, sizeof u);
+      REAL_VALUE_FROM_CONST_DOUBLE (u.d, SUBREG_REG (XEXP (x, 0)));
       fprintf (file, "(%.20e)", u.d);
     }
 
@@ -1182,7 +1181,7 @@ print_operand (file, x, code)
     {
       union real_extract u;
 
-      bcopy ((char *) &CONST_DOUBLE_LOW (x), (char *) &u, sizeof u);
+      REAL_VALUE_FROM_CONST_DOUBLE (u.d, x);
       fprintf (file, "$%s(%.20e)",
 	       GET_MODE (x) == SFmode ? "float" : "double0", u.d);
     }

--- a/gcc/config/arm/arm.c
+++ b/gcc/config/arm/arm.c
@@ -4091,8 +4091,7 @@ output_move_double (operands)
 	      long l[2];
 	      union real_extract u;
 
-	      bcopy ((char *) &CONST_DOUBLE_LOW (operands[1]), (char *) &u,
-		     sizeof (u));
+	      REAL_VALUE_FROM_CONST_DOUBLE (u.d, operands[1]);
 	      REAL_VALUE_TO_TARGET_DOUBLE (u.d, l);
 	      otherops[1] = GEN_INT(l[1]);
 	      operands[1] = GEN_INT(l[0]);

--- a/gcc/config/arm/arm.md
+++ b/gcc/config/arm/arm.md
@@ -6215,7 +6215,7 @@
     case MODE_FLOAT:
     {
       union real_extract u;
-      bcopy ((char *) &CONST_DOUBLE_LOW (operands[0]), (char *) &u, sizeof u);
+      REAL_VALUE_FROM_CONST_DOUBLE (u.d, operands[0]);
       assemble_real (u.d, GET_MODE (operands[0]));
       break;
     }
@@ -6237,7 +6237,7 @@
     case MODE_FLOAT:
     {
       union real_extract u;
-      bcopy ((char *) &CONST_DOUBLE_LOW (operands[0]), (char *) &u, sizeof u);
+      REAL_VALUE_FROM_CONST_DOUBLE (u.d, operands[0]);
       assemble_real (u.d, GET_MODE (operands[0]));
       break;
     }

--- a/gcc/config/arm/thumb.md
+++ b/gcc/config/arm/thumb.md
@@ -1094,7 +1094,7 @@
     case MODE_FLOAT:
     {
       union real_extract u;
-      bcopy ((char *) &CONST_DOUBLE_LOW (operands[0]), (char *) &u, sizeof u);
+      REAL_VALUE_FROM_CONST_DOUBLE (u.d, operands[0]);
       assemble_real (u.d, GET_MODE (operands[0]));
       break;
     }
@@ -1116,7 +1116,7 @@
     case MODE_FLOAT:
     {
       union real_extract u;
-      bcopy ((char *) &CONST_DOUBLE_LOW (operands[0]), (char *) &u, sizeof u);
+      REAL_VALUE_FROM_CONST_DOUBLE (u.d, operands[0]);
       assemble_real (u.d, GET_MODE (operands[0]));
       break;
     }

--- a/gcc/config/m88k/m88k.c
+++ b/gcc/config/m88k/m88k.c
@@ -1160,7 +1160,7 @@ legitimize_operand (op, mode)
 
   if (GET_CODE (op) == CONST_DOUBLE)
     {
-      bcopy (&CONST_DOUBLE_LOW (op), &u.r, sizeof u);
+      REAL_VALUE_FROM_CONST_DOUBLE (u.r.d, op);
       if (u.d.exponent != 0x7ff /* NaN */
 	  && u.d.mantissa2 == 0 /* Mantissa fits */
 	  && (u.s.exponent1 == 0x8 || u.s.exponent1 == 0x7) /* Exponent fits */

--- a/gcc/config/m88k/m88k.md
+++ b/gcc/config/m88k/m88k.md
@@ -3068,7 +3068,7 @@
   if (real_power_of_2_operand (operands[2]))
     {
       union real_extract u;
-      bcopy (&CONST_DOUBLE_LOW (operands[2]), &u, sizeof u);
+      REAL_VALUE_FROM_CONST_DOUBLE (u.d, operands[2]);
       emit_insn (gen_muldf3 (operands[0], operands[1],
 			     CONST_DOUBLE_FROM_REAL_VALUE (1.0/u.d, DFmode)));
       DONE;

--- a/gcc/config/mips/mips.md
+++ b/gcc/config/mips/mips.md
@@ -9843,7 +9843,7 @@ move\\t%0,%z4\\n\\
 
   if (GET_CODE (operands[0]) != CONST_DOUBLE)
     abort ();
-  bcopy ((char *) &CONST_DOUBLE_LOW (operands[0]), (char *) &u, sizeof u);
+  REAL_VALUE_FROM_CONST_DOUBLE (u.d, operands[0]);
   assemble_real (u.d, SFmode);
   return \"\";
 }"
@@ -9860,7 +9860,7 @@ move\\t%0,%z4\\n\\
 
   if (GET_CODE (operands[0]) != CONST_DOUBLE)
     abort ();
-  bcopy ((char *) &CONST_DOUBLE_LOW (operands[0]), (char *) &u, sizeof u);
+  REAL_VALUE_FROM_CONST_DOUBLE (u.d, operands[0]);
   assemble_real (u.d, DFmode);
   return \"\";
 }"

--- a/gcc/config/romp/romp.c
+++ b/gcc/config/romp/romp.c
@@ -1953,8 +1953,7 @@ output_fpops (file)
 		{
 		  union real_extract u;
 
-		  bcopy ((char *) &CONST_DOUBLE_LOW (immed[i]),
-			 (char *) &u, sizeof u);
+		  REAL_VALUE_FROM_CONST_DOUBLE (u.d, immed[i]);
 		  if (GET_MODE (immed[i]) == DFmode)
 		    ASM_OUTPUT_DOUBLE (file, u.d);
 		  else

--- a/gcc/config/sh/sh.md
+++ b/gcc/config/sh/sh.md
@@ -2872,7 +2872,7 @@
  "*
 {
   union real_extract u;
-  bcopy ((char *) &CONST_DOUBLE_LOW (operands[0]), (char *) &u, sizeof u);
+  REAL_VALUE_FROM_CONST_DOUBLE (u.d, operands[0]);
   assemble_real (u.d, SFmode);
   return \"\";
 }"
@@ -2887,7 +2887,7 @@
  "*
 {
   union real_extract u;
-  bcopy ((char *) &CONST_DOUBLE_LOW (operands[0]), (char *) &u, sizeof u);
+  REAL_VALUE_FROM_CONST_DOUBLE (u.d, operands[0]);
   assemble_real (u.d, DFmode);
   return \"\";
 }"

--- a/gcc/emit-rtl.c
+++ b/gcc/emit-rtl.c
@@ -3450,12 +3450,11 @@ init_emit_once (line_numbers)
 	   mode = GET_MODE_WIDER_MODE (mode))
 	{
 	  rtx tem = rtx_alloc (CONST_DOUBLE);
-	  union real_extract u;
+	  REAL_VALUE_TYPE d;
 
-	  bzero ((char *) &u, sizeof u);  /* Zero any holes in a structure.  */
-	  u.d = i == 0 ? dconst0 : i == 1 ? dconst1 : dconst2;
+	  d = i == 0 ? dconst0 : i == 1 ? dconst1 : dconst2;
 
-	  bcopy ((char *) &u, (char *) &CONST_DOUBLE_LOW (tem), sizeof u);
+	  CONST_DOUBLE_SET_REAL_VALUE (tem, d);
 	  CONST_DOUBLE_MEM (tem) = cc0_rtx;
 	  PUT_MODE (tem, mode);
 

--- a/gcc/real.h
+++ b/gcc/real.h
@@ -444,17 +444,35 @@ union real_extract
    or cc0_rtx if it is not on the chain.  */
 #define CONST_DOUBLE_MEM(r) XEXP (r, 0)
 
-/* Given a CONST_DOUBLE in FROM, store into TO the value it represents.  */
 /* Function to return a real value (not a tree node)
    from a given integer constant.  */
 union tree_node;
 REAL_VALUE_TYPE real_value_from_int_cst	PROTO ((union tree_node *,
 						union tree_node *));
 
+/* The macros below now assume that REAL_VALUE_TYPE is a double and that
+   HOST_WIDE_INT is a 32-bit int.  */
+
+_Static_assert (sizeof (REAL_VALUE_TYPE) == sizeof (double),
+		"REAL_VALUE_TYPE is not a double");
+_Static_assert (sizeof (HOST_WIDE_INT) == 4,
+		"HOST_WIDE_INT is not a 32-bit int");
+
+/* Given a CONST_DOUBLE in FROM, store into TO the value it represents.  */
+
 #define REAL_VALUE_FROM_CONST_DOUBLE(to, from)		\
-do { union real_extract u;				\
-     bcopy ((char *) &CONST_DOUBLE_LOW ((from)), (char *) &u, sizeof u); \
-     to = u.d; } while (0)
+do { union real_extract __u;				\
+     __u.i[0] = CONST_DOUBLE_LOW (from);		\
+     __u.i[1] = CONST_DOUBLE_HIGH (from);		\
+     to = __u.d; } while (0)
+
+/* Given a CONST_DOUBLE in R, replace the value it represents with V.  */
+
+#define CONST_DOUBLE_SET_REAL_VALUE(r, v)		\
+do { union real_extract __u;				\
+     __u.d = (v);					\
+     CONST_DOUBLE_LOW (r) = __u.i[0];			\
+     CONST_DOUBLE_HIGH (r) = __u.i[1]; } while (0)
 
 /* Return a CONST_DOUBLE with value R and mode M.  */
 

--- a/gcc/varasm.c
+++ b/gcc/varasm.c
@@ -2083,9 +2083,13 @@ immed_real_const_1 (d, mode)
      If one is found, return it.  */
 
   for (r = const_double_chain; r; r = CONST_DOUBLE_CHAIN (r))
-    if (! bcmp ((char *) &CONST_DOUBLE_LOW (r), (char *) &u, sizeof u)
-	&& GET_MODE (r) == mode)
-      return r;
+    {
+      REAL_VALUE_TYPE d2;
+
+      REAL_VALUE_FROM_CONST_DOUBLE (d2, r);
+      if (REAL_VALUES_IDENTICAL(d, d2) && GET_MODE (r) == mode)
+	return r;
+    }
 
   /* No; make a new one and add it to the chain.
 
@@ -2099,7 +2103,7 @@ immed_real_const_1 (d, mode)
   rtl_in_saveable_obstack ();
   r = rtx_alloc (CONST_DOUBLE);
   PUT_MODE (r, mode);
-  bcopy ((char *) &u, (char *) &CONST_DOUBLE_LOW (r), sizeof u);
+  CONST_DOUBLE_SET_REAL_VALUE (r, d);
   pop_obstacks ();
 
   /* Don't touch const_double_chain in nested function; see force_const_mem.
@@ -3220,8 +3224,7 @@ decode_rtx_const (mode, x, value)
       if (GET_MODE (x) != VOIDmode)
 	{
 	  value->mode = GET_MODE (x);
-	  bcopy ((char *) &CONST_DOUBLE_LOW (x),
-		 (char *) &value->un.du, sizeof value->un.du);
+	  REAL_VALUE_FROM_CONST_DOUBLE (value->un.du.d, x);
 	}
       else
 	{
@@ -3645,7 +3648,7 @@ output_constant_pool (fnname, fndecl)
 	  if (GET_CODE (x) != CONST_DOUBLE)
 	    abort ();
 
-	  bcopy ((char *) &CONST_DOUBLE_LOW (x), (char *) &u, sizeof u);
+	  REAL_VALUE_FROM_CONST_DOUBLE (u.d, x);
 	  assemble_real (u.d, pool->mode);
 	  break;
 


### PR DESCRIPTION
Currently the macOS version miscompiles basically anything involving `double` constants. On 32-bit machines (e.g. Linux builds), for a `struct rtx_def *r` that represents a const double the value is split into two parts, accessed as
```c
#define CONST_DOUBLE_LOW(r) XWINT (r, 2)  // r->fld[2].rtwint
#define CONST_DOUBLE_HIGH(r) XWINT (r, 3) // r->fld[3].rtwint
```
and the value is usually copied out like
```c
union real_extract u;
bcopy ((char *) &CONST_DOUBLE_LOW (r), (char *) &u, sizeof (u));
```
which assumes that `CONST_DOUBLE_LOW` and `CONST_DOUBLE_HIGH` are 4 bytes apart in memory. On macOS we compile as 64-bit though, meaning this `bcopy` will ignore `CONST_DOUBLE_HIGH`.

Currently on macOS `HOST_BITS_PER_LONG` is `32` and `HOST_WIDE_INT` is `int` which is kind of a lie. Technically we could fix const doubles by changing `HOST_BITS_PER_LONG` to `64` (then the code would put entire double values in `CONST_DOUBLE_LOW` instead of splitting it into two parts) but I'm concerned that this would break matching, since other code uses `CONST_DOUBLE_LOW`/`CONST_DOUBLE_HIGH` directly for hashing and such.

Updating all the backends was probably not necessary but it's nice to be consistent I guess.